### PR TITLE
Oyuncu Dakika Tutma

### DIFF
--- a/code/controllers/subsystem/playerTimeLog.dm
+++ b/code/controllers/subsystem/playerTimeLog.dm
@@ -4,6 +4,10 @@ SUBSYSTEM_DEF(oyuncuDakikaTut)
 
 /datum/controller/subsystem/oyuncuDakikaTut/fire(resumed)
 	var/logFile = file("data/playerMinutes.json")
+	
+	if(!(logFile in flist("data/")))
+		text2file("{}", logFile)
+	
 	var/playerMinuteList = json_decode(file2text(logFile))
 	fdel(logFile)
 

--- a/code/controllers/subsystem/playerTimeLog.dm
+++ b/code/controllers/subsystem/playerTimeLog.dm
@@ -1,0 +1,13 @@
+SUBSYSTEM_DEF(oyuncuDakikaTut)
+    name = "oyuncuDakikaTut"
+    wait = 60 SECONDS
+
+/datum/controller/subsystem/oyuncuDakikaTut/fire(resumed)
+	var/logFile = file("data/playerMinutes.json")
+	var/playerMinuteList = json_decode(file2text(logFile))
+	fdel(logFile)
+
+	for(var/client/C in GLOB.clients)
+		playerMinuteList[C.key] += 1
+
+	WRITE_FILE(logFile, json_encode(playerMinuteList))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -445,6 +445,7 @@
 #include "code\controllers\subsystem\blackbox.dm"
 #include "code\controllers\subsystem\blackmarket.dm"
 #include "code\controllers\subsystem\botagonderme.dm"
+#include "code\controllers\subsystem\playerTimeLog.dm"
 #include "code\controllers\subsystem\chat.dm"
 #include "code\controllers\subsystem\circuit_component.dm"
 #include "code\controllers\subsystem\communications.dm"


### PR DESCRIPTION
Sunucuda bulunan oyuncuların dakikalarını tutmayı sağlayan bir kod ekler.

Çalışma Mantığı:

Her dakika sunucuda bulunan oyuncuların listesini alıp her bir oyuncunun değerini "data/playerMinutes.json" klasöründe arttırır. Eğer dosya bulunmuyorsa dosyayı oluşturur.