### PR TITLE
integrated circuitler için keyboard component

### DIFF
--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -416,6 +416,11 @@
 	id = "comp_access_checker"
 	build_path = /obj/item/circuit_component/compare/access
 
+/datum/design/component/keyboard
+	name = "Keyboard Component"
+	id = "comp_keyboard"
+	build_path = /obj/item/circuit_component/keyboard
+
 /datum/design/compact_remote_shell
 	name = "Compact Remote Shell"
 	desc = "A handheld shell with one big button."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -259,6 +259,7 @@
 		"comp_index",
 		"comp_index_assoc",
 		"comp_index_table",
+		"comp_keyboard",
 		"comp_laserpointer",
 		"comp_length",
 		"comp_light",

--- a/code/modules/wiremod/components/atom/keyboard.dm
+++ b/code/modules/wiremod/components/atom/keyboard.dm
@@ -1,0 +1,39 @@
+/obj/item/circuit_component/keyboard
+	display_name = "Keyboard"
+	desc = "A component that allows the user to input a string"
+	category = "Entity"
+
+	var/datum/port/input/entity
+
+	var/datum/port/input/input_name
+	var/datum/port/input/input_desc
+
+	var/datum/port/output/output
+
+	var/datum/port/output/failure
+	var/ready = TRUE
+
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL
+
+/obj/item/circuit_component/keyboard/populate_ports()
+	entity = add_input_port("User", PORT_TYPE_ATOM)
+	input_name = add_input_port("Input Name", PORT_TYPE_STRING)
+	input_desc = add_input_port("Input Description", PORT_TYPE_STRING)
+	output = add_output_port("Message", PORT_TYPE_STRING)
+	trigger_output = add_output_port("Triggered", PORT_TYPE_SIGNAL)
+	failure = add_output_port("On Failure", PORT_TYPE_SIGNAL)
+
+/obj/item/circuit_component/keyboard/input_received(datum/port/input/port)
+	if(!ready)
+		failure.set_output(COMPONENT_SIGNAL)
+		return
+
+	INVOKE_ASYNC(src, .proc/get_input)
+	ready = FALSE
+
+/obj/item/circuit_component/keyboard/proc/get_input()
+	var/message = tgui_input_text(entity.value, input_desc.value ? input_desc.value : "", input_name.value ? input_name.value : "Keyboard", "")
+	output.set_output(message)
+	trigger_output.set_output(COMPONENT_SIGNAL)
+	ready = TRUE
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4578,6 +4578,7 @@
 #include "code\modules\wiremod\components\atom\gps.dm"
 #include "code\modules\wiremod\components\atom\health.dm"
 #include "code\modules\wiremod\components\atom\hear.dm"
+#include "code\modules\wiremod\components\atom\keyboard.dm"
 #include "code\modules\wiremod\components\atom\matscanner.dm"
 #include "code\modules\wiremod\components\atom\pinpointer.dm"
 #include "code\modules\wiremod\components\atom\reagentscanner.dm"


### PR DESCRIPTION
-Keyboard component triggerlandığında bir input penceresi açıyor ve buraya yazılanı output olarak veriyor
-Input penceresini, entity inputundan aldığı entity için açıyor yani entity inputunun boş bırakılmaması önemli
-Açılan penceredeki pencere adı ve açıklaması özelleştirilebiliyor.

Örnek kullanım:
![Screenshot (447)](https://user-images.githubusercontent.com/109217145/183469871-e424cf6c-4a32-47fd-beeb-c8890a7f16a4.png)

Açılan pencere:
![Screenshot (448)](https://user-images.githubusercontent.com/109217145/183471638-88901dc9-2c17-45b7-a249-6e21d443b665.png)